### PR TITLE
JP2 file access if now backwards compatible

### DIFF
--- a/kmeans_ndvi/utils.py
+++ b/kmeans_ndvi/utils.py
@@ -179,7 +179,6 @@ def download_tile_band(href, collection='sentinel-s2-l2a-cogs', s3_client=None):
 
     # Check if file already exists to skip double downloading
     if not os.path.exists(output_filepath):
-        debug_message(f"collection:{collection}")
         if 'cogs' in collection:
             download(url=href, out=output_filepath)
         else:


### PR DESCRIPTION
1. Added `collection=self.collection` to `download_tile_band` in new behaviour
2. Tested that both JP2 files and GeoTIFF files can be downloaded with a simple CLI flag `--collection sentinel-s2-l2a`